### PR TITLE
Add support for optionals in struct fields

### DIFF
--- a/example/example.mjs
+++ b/example/example.mjs
@@ -10,8 +10,6 @@ console.log('1 + 2 =', native.add(1, 2))
 // Test our struct-based function
 const person = {
     name: 'John Doe',
-    // age: 30,
-    agex: 30,
 }
 
 console.log('Original person:', person)

--- a/example/example.mjs
+++ b/example/example.mjs
@@ -5,4 +5,15 @@ import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
 const native = require('./zig-out/lib/example.node')
 
-console.log('1 + 2 =', native.add(1, 2));
+console.log('1 + 2 =', native.add(1, 2))
+
+// Test our struct-based function
+const person = {
+    name: 'John Doe',
+    // age: 30,
+    agex: 30,
+}
+
+console.log('Original person:', person)
+const updatedPerson = native.updatePerson(person)
+console.log('Updated person:', updatedPerson)

--- a/example/src/main.zig
+++ b/example/src/main.zig
@@ -5,12 +5,36 @@ export fn add(a: i32, b: i32) i32 {
     return a + b;
 }
 
+const Person = struct {
+    name: []const u8,
+    age: ?u32,
+};
+
+fn incrementAge(person: Person) Person {
+    return .{
+        .name = person.name,
+        .age = if (person.age) |age| age + 1 else null,
+    };
+}
+
+fn updatePersonWrapper(js: *napigen.JsContext, person: napigen.napi_value) !napigen.napi_value {
+    // Read Person from JS object
+    const p = try js.readObject(Person, person);
+
+    // Apply our function
+    const result = incrementAge(p);
+
+    // Write result back to JS
+    return js.createObjectFrom(result);
+}
+
 comptime {
     napigen.defineModule(initModule);
 }
 
-fn initModule(js: *napigen.JsContext, exports: napigen.napi_value) anyerror!napigen.napi_value {
+fn initModule(js: *napigen.JsContext, exports: napigen.napi_value) !napigen.napi_value {
     try js.setNamedProperty(exports, "add", try js.createFunction(add));
+    try js.setNamedProperty(exports, "updatePerson", try js.createFunction(updatePersonWrapper));
 
     return exports;
 }


### PR DESCRIPTION
Previously the compiler was failing when adding an optional field in a struct because the `.read` method was returning a type different than the type argument T, not it just wraps the non optional type in an optional so that the function signature is satisfied